### PR TITLE
Alphafox02 patch 4

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1526,6 +1526,28 @@ void SoapySidekiq::setBandwidth(const int direction, const size_t channel,
     }
 }
 
+std::vector<double> SoapySidekiq::listSampleRates(const int direction, const size_t channel) const {
+  std::vector<double> results;
+
+  uint32_t min_sample_rate;
+  if (skiq_read_min_sample_rate(card, &min_sample_rate) != 0) {
+    SoapySDR_logf(SOAPY_SDR_ERROR, "Failure: skiq_read_min_sample_rate (card %d)", card);
+  }
+  uint32_t max_sample_rate;
+  if (skiq_read_max_sample_rate(card, &max_sample_rate) != 0) {
+    SoapySDR_logf(SOAPY_SDR_ERROR, "Failure: skiq_read_min_sample_rate (card %d)", card);
+  }
+
+  //  iterate through all sample rates
+  uint32_t sample_rate = min_sample_rate;
+  while (sample_rate <= max_sample_rate) {
+    results.push_back(sample_rate);
+    sample_rate += 250000;
+  }
+
+  return results;
+}
+
 double SoapySidekiq::getBandwidth(const int    direction,
                                   const size_t channel) const
 {

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -823,7 +823,6 @@ void SoapySidekiq::setGain(const int direction, const size_t channel, const doub
         SoapySDR_logf(SOAPY_SDR_INFO,
             "Set RX gain to: %.1f dB (gain index: %u)", value, gain_index);
     }
-}
 
     /* For TX gain is attenuation 
      * so a gain of 0 is max attenuation_index. A large gain, is a smaller attenuation index */

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -726,6 +726,11 @@ bool SoapySidekiq::getGainMode(const int direction, const size_t channel) const
     return false;
 }
 
+void SoapySidekiq::setGain(const int direction, const size_t channel, const std::string &name, const double value)
+{
+    setGain(direction, channel, value);
+}
+
 void SoapySidekiq::setGain(const int direction, const size_t channel, const double value)
 {
     int status = 0;
@@ -869,6 +874,11 @@ void SoapySidekiq::setGain(const int direction, const size_t channel, const doub
         SoapySDR_logf(SOAPY_SDR_ERROR, "invalid direction %d", direction);
         throw std::runtime_error("");
     }
+}
+
+double SoapySidekiq::getGain(const int direction, const size_t channel, const std::string &name) const
+{
+    return getGain(direction, channel);
 }
 
 double SoapySidekiq::getGain(const int direction, const size_t channel) const

--- a/SoapySidekiq.hpp
+++ b/SoapySidekiq.hpp
@@ -144,7 +144,16 @@ class SoapySidekiq : public SoapySDR::Device
 
         void setGain(const int direction,
                 const size_t channel,
+                const std::string &name,
                 const double value);
+
+        void setGain(const int direction,
+                const size_t channel,
+                const double value) override;
+ 
+        double getGain(const int direction,
+                const size_t channel,
+                const std::string &name) const override;
 
         double getGain(const int direction,
                 const size_t channel) const;

--- a/SoapySidekiq.hpp
+++ b/SoapySidekiq.hpp
@@ -308,6 +308,10 @@ class SoapySidekiq : public SoapySDR::Device
         uint32_t rxReadIndex{};
         uint32_t rxWriteIndex{};
 
+        // Buffer for leftover RX samples to allow readStream() to return arbitrary numElems
+        std::vector<int16_t> rx_fifo_buffer;
+        size_t rx_fifo_offset = 0;
+
         // TX buffer
         skiq_tx_block_t *p_tx_block[DEFAULT_NUM_BUFFERS];
         uint32_t currTXBuffIndex{};

--- a/SoapySidekiq.hpp
+++ b/SoapySidekiq.hpp
@@ -183,6 +183,8 @@ class SoapySidekiq : public SoapySDR::Device
         SoapySDR::RangeList getSampleRateRange(const int    direction,
                 const size_t channel) const;
 
+        std::vector<double> listSampleRates(const int direction, const size_t channel) const override;
+
         void setBandwidth(const int direction,
                 const size_t channel,
                 const double bw);

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -673,11 +673,19 @@ int SoapySidekiq::deactivateStream(SoapySDR::Stream *stream, const int flags,
             status = skiq_stop_rx_streaming_on_1pps(card, rx_hdl, 0);
             if (status != 0)
             {
-                SoapySDR_logf(SOAPY_SDR_ERROR,
-                        "skiq_stop_rx_streaming_on_1pps failed, (card %u) handle "
-                        "%d, status %d",
+                if (status == -19) // Handle not streaming
+                {
+                    SoapySDR_logf(SOAPY_SDR_WARNING,
+                        "skiq_stop_rx_streaming_on_1pps: handle not streaming (card %u, handle %d), ignoring",
+                        card, rx_hdl);
+                }
+                else
+                {
+                    SoapySDR_logf(SOAPY_SDR_ERROR,
+                        "skiq_stop_rx_streaming_on_1pps failed, (card %u) handle %d, status %d",
                         card, rx_hdl, status);
-                throw std::runtime_error("");
+                    throw std::runtime_error("");
+                }
             }
         }
         else
@@ -685,11 +693,19 @@ int SoapySidekiq::deactivateStream(SoapySDR::Stream *stream, const int flags,
             status = skiq_stop_rx_streaming(card, rx_hdl);
             if (status != 0)
             {
-                SoapySDR_logf(SOAPY_SDR_ERROR,
-                        "skiq_stop_rx_streaming failed, (card %u) handle "
-                        "%d, status %d",
+                if (status == -19) // Handle not streaming
+                {
+                    SoapySDR_logf(SOAPY_SDR_WARNING,
+                        "skiq_stop_rx_streaming: handle not streaming (card %u, handle %d), ignoring",
+                        card, rx_hdl);
+                }
+                else
+                {
+                    SoapySDR_logf(SOAPY_SDR_ERROR,
+                        "skiq_stop_rx_streaming failed, (card %u) handle %d, status %d",
                         card, rx_hdl, status);
-                throw std::runtime_error("");
+                    throw std::runtime_error("");
+                }
             }
         }
 
@@ -707,11 +723,19 @@ int SoapySidekiq::deactivateStream(SoapySDR::Stream *stream, const int flags,
             status = skiq_stop_tx_streaming_on_1pps(card, tx_hdl, 0);
             if (status != 0)
             {
-                SoapySDR_logf(
-                        SOAPY_SDR_ERROR,
+                if (status == -19)
+                {
+                    SoapySDR_logf(SOAPY_SDR_WARNING,
+                        "skiq_stop_tx_streaming_on_1pps: handle not streaming (card %u, handle %d), ignoring",
+                        card, tx_hdl);
+                }
+                else
+                {
+                    SoapySDR_logf(SOAPY_SDR_ERROR,
                         "skiq_stop_tx_streaming_on_1pps failed (card %u), status %d",
                         card, status);
-                throw std::runtime_error("");
+                    throw std::runtime_error("");
+                }
             }
 
             /* verify the tx thread is done */
@@ -726,14 +750,21 @@ int SoapySidekiq::deactivateStream(SoapySDR::Stream *stream, const int flags,
             status = skiq_stop_tx_streaming(card, tx_hdl);
             if (status != 0)
             {
-                SoapySDR_logf(
-                        SOAPY_SDR_ERROR,
+                if (status == -19)
+                {
+                    SoapySDR_logf(SOAPY_SDR_WARNING,
+                        "skiq_stop_tx_streaming: handle not streaming (card %u, handle %d), ignoring",
+                        card, tx_hdl);
+                }
+                else
+                {
+                    SoapySDR_logf(SOAPY_SDR_ERROR,
                         "skiq_stop_tx_streaming failed (card %u), status %d",
                         card, status);
-                throw std::runtime_error("");
+                    throw std::runtime_error("");
+                }
             }
         }
-
     }
 
     return 0;

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -739,55 +739,54 @@ int SoapySidekiq::deactivateStream(SoapySDR::Stream *stream, const int flags,
     return 0;
 }
 
-int SoapySidekiq::readStream(SoapySDR::Stream *stream, void *const *buffs,
-                             const size_t numElems, int &flags,
-                             long long &timeNs, const long timeoutUs)
+int SoapySidekiq::readStream(
+    SoapySDR::Stream *stream,
+    void *const *buffs,
+    const size_t numElems,
+    int &flags,
+    long long &timeNs,
+    const long timeoutUs)
 {
     if (stream != RX_STREAM)
-    {
         return SOAPY_SDR_NOT_SUPPORTED;
-    }
     else if (rx_receive_operation_exited_due_to_error)
-    {
         return SOAPY_SDR_STREAM_ERROR;
+
+    int16_t *output = static_cast<int16_t *>(buffs[0]);
+    size_t totalCopied = 0;
+    long waitTime = (timeoutUs == 0) ? SLEEP_1SEC : timeoutUs;
+
+    // 1. Drain from FIFO buffer if there is leftover data from previous read
+    while (!rx_fifo_buffer.empty() && totalCopied < numElems) {
+        output[totalCopied++] = rx_fifo_buffer[rx_fifo_offset++];
+        if (rx_fifo_offset >= rx_fifo_buffer.size()) {
+            rx_fifo_buffer.clear();
+            rx_fifo_offset = 0;
+        }
     }
 
-    // ---- Enforce that client must read multiples of RX block size (like gr-sidekiq) ----
-    if (numElems % rx_payload_size_in_words != 0)
-    {
-        SoapySDR_logf(SOAPY_SDR_ERROR, "numElems must be a multiple of the RX block size numElems %zu, block size %u",
-                     numElems, rx_payload_size_in_words);
-        throw std::runtime_error("");
-    }
+    // 2. If we've satisfied the request, return
+    if (totalCopied == numElems)
+        return numElems;
 
-    long waitTime = timeoutUs;
-    if (waitTime == 0)
-        waitTime = SLEEP_1SEC;
-
-    // Wait for enough blocks
-    size_t blocks_needed = numElems / rx_payload_size_in_words;
-    size_t blocks_read = 0;
-    char *buff_ptr = (char *)buffs[0];
-
-    while (blocks_read < blocks_needed)
-    {
-        while ((rxReadIndex == rxWriteIndex) && (waitTime > 0))
-        {
+    // 3. Otherwise, fetch more blocks from the hardware ring buffer
+    while (totalCopied < numElems) {
+        // Wait for data to be available
+        while (rxReadIndex == rxWriteIndex && waitTime > 0) {
             usleep(DEFAULT_SLEEP_US);
             waitTime -= DEFAULT_SLEEP_US;
         }
-        if (waitTime <= 0)
-        {
+        if (waitTime <= 0) {
             SoapySDR_log(SOAPY_SDR_DEBUG, "readStream timed out");
-            return SOAPY_SDR_TIMEOUT;
+            return (totalCopied > 0) ? totalCopied : SOAPY_SDR_TIMEOUT;
         }
 
         skiq_rx_block_t *block_ptr = p_rx_block[rxReadIndex];
-        char *ringbuffer_ptr = (char *)((char *)block_ptr->data);
+        int16_t *src = reinterpret_cast<int16_t *>(block_ptr->data);
+        size_t samplesInBlock = rx_payload_size_in_bytes / sizeof(int16_t);
 
-        // Timestamp reporting (use first block's timestamp)
-        if (blocks_read == 0)
-        {
+        // Set timeNs and flags for the very first sample returned
+        if (totalCopied == 0) {
             if (this->rfTimeSource == true)
                 timeNs = convert_timestamp_to_nanos(block_ptr->rf_timestamp, rx_sample_rate);
             else
@@ -795,31 +794,26 @@ int SoapySidekiq::readStream(SoapySDR::Stream *stream, void *const *buffs,
             flags = SOAPY_SDR_HAS_TIME;
         }
 
-        // Copy block
-        if (rxUseShort)
-        {
-            memcpy(buff_ptr, ringbuffer_ptr, rx_payload_size_in_bytes);
-        }
-        else
-        {
-            float *dbuff_ptr = (float *)buff_ptr;
-            int16_t *source = (int16_t *)ringbuffer_ptr;
-            int short_ctr = 0;
-            for (size_t i = 0; i < rx_payload_size_in_words; i++)
-            {
-                *dbuff_ptr++ = (float)source[short_ctr + 1] / this->maxValue;
-                *dbuff_ptr++ = (float)source[short_ctr] / this->maxValue;
-                short_ctr += 2;
-            }
+        // How many can we copy directly?
+        size_t needed = numElems - totalCopied;
+        if (needed >= samplesInBlock) {
+            // Copy full block
+            memcpy(&output[totalCopied], src, samplesInBlock * sizeof(int16_t));
+            totalCopied += samplesInBlock;
+        } else {
+            // Copy partial block, save remainder for next call
+            memcpy(&output[totalCopied], src, needed * sizeof(int16_t));
+            // Save the leftovers in the FIFO buffer
+            rx_fifo_buffer.assign(&src[needed], &src[samplesInBlock]);
+            rx_fifo_offset = 0;
+            totalCopied += needed;
         }
 
-        buff_ptr += rx_payload_size_in_bytes;
+        // Move to the next buffer in the ring
         rxReadIndex = (rxReadIndex + 1) % DEFAULT_NUM_BUFFERS;
-        blocks_read++;
     }
 
-    // NumElems samples have been written to user's buffer
-    return numElems;
+    return totalCopied;
 }
 
 int SoapySidekiq::writeStream(SoapySDR::Stream * stream,


### PR DESCRIPTION
This PR attempts to improve support for Epiq Solutions Sidekiq SDRs in SoapySDR. 

Main features tested so far:

Device enumeration and initialization through SoapySDR.
Sample rate, bandwidth, gain (auto/manual), and center frequency controls all function as expected.
RX/TX threading, buffer management, and error handling appear stable.
Data display and streaming confirmed in SoapySDRUtil, SigDigger, and GQRX using the default format (CS16).

Block Size & Streaming Changes
Previously, the streaming (ring buffer) implementation was locked to a fixed block size of 1018 samples, matching the hardware's RX block. Through testing, this proved problematic with many FOSS SDR applications, which tend to expect a standard buffer size (like 4096 samples) from SoapySDR drivers. I reverted the streaming logic to dynamically accumulate and serve RX data in blocks matching client requests, rather than enforcing the hardware block size. This approach seems to improve compatibility and data integrity in the apps I've tested so far.

Notes & Outstanding Issues
CF32 Format:
The driver advertises support for CF32 (float) stream format, but I have not tested this mode in practice. Additional verification from others would be appreciated.

CubicSDR Compatibility (Needs Attention):
CubicSDR detects the device and begins streaming (logs look correct), but no signal appears in the FFT or waterfall. Other applications (GQRX, SigDigger) work fine. This could be a format handling or integration issue unique to CubicSDR, and I would welcome any help from others who have worked with this SDR and software combo.

Further Testing Needed:
These improvements have mostly been tested on a single platform and use case. Broader testing—especially with different applications and configurations—would help ensure robustness and catch any remaining edge cases.