### PR TITLE
Update for compat with newer CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################################
 # Build Soapy SDR support module for Sidekiq Devices
 ########################################################################
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12...3.10)
 project(SoapySidekiq CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
This updates the projects CMake requirements to allow modern cmake versions to work.
No actual change (apart from the point update .7 to .12) to the projects minimum CMake requirements itself.